### PR TITLE
Fix interpreter bug

### DIFF
--- a/src/electron/lib/core-graph/CoreGraphInterpreter.ts
+++ b/src/electron/lib/core-graph/CoreGraphInterpreter.ts
@@ -140,6 +140,8 @@ export class CoreGraphInterpreter {
               graph.getAnchors[graph.getEdgeDest[anchor].getAnchorFrom]
             )
           );
+        } else {
+          inputPromises.push(Promise.resolve({}));
         }
       }
     }
@@ -173,7 +175,6 @@ export class CoreGraphInterpreter {
       return output;
     } else {
       const inputDict: { [key: string]: any } = {};
-
       Object.values(curr.getAnchors).forEach((anchor, index) => {
         if (index < inputs.length) {
           inputDict[anchor.anchorId] = graph.getEdgeDest[anchor.uuid]


### PR DESCRIPTION
A node can now have multiple input anchors without the interpreter dying. It was passing the wrong value when you skip an anchor.