### PR TITLE
Add extra check for equivalence of media outputIds

### DIFF
--- a/src/frontend/lib/stores/MediaStore.ts
+++ b/src/frontend/lib/stores/MediaStore.ts
@@ -83,6 +83,7 @@ class MediaStore {
 }
 
 function equivSets<T>(s1: Set<T>, s2: Set<T>): boolean {
+  if (s1.size !== s2.size) return false;
   for (const element of s1) {
     if (!s2.has(element)) {
       return false;


### PR DESCRIPTION
Was an error caused due to an oversight of mine. I checked for the difference of outputIds when updating the frontend but did not account for the case when ids are added or removed. :(