### PR TITLE
Fix pane deletion bug causing exception in Splitpanes

### DIFF
--- a/src/frontend/lib/Project.ts
+++ b/src/frontend/lib/Project.ts
@@ -14,29 +14,25 @@ let groupTest = 0;
 
 /**
  * Constructs a PanelGroup from a LayoutPanel
+ *
  * @param layout The layout to construct from
  * @returns The constructed PanelGroup
  */
-
 export function constructLayout(layout: LayoutPanel): PanelGroup {
   const group = new PanelGroup((groupTest++).toString());
-  if (layout.panels) {
-    for (const panel of layout.panels) {
-      if (panel.panels) {
-        group.addPanelGroup(constructLayout(panel), panel.panels.length);
-      } else {
-        if (panel.content) {
-          group.addPanel(panel.content, layout.panels.length);
-        }
+
+  layout.panels?.forEach((panel) => {
+    if (panel.panels) {
+      group.addPanelGroup(constructLayout(panel));
+    } else {
+      if (panel.content) {
+        group.addPanel(panel.content);
       }
     }
-    return group;
-  }
+  });
+
   return group;
 }
-/**
- * A layout template for the UI
- */
 
 export const layoutTemplate: LayoutPanel = {
   panels: [

--- a/src/frontend/lib/stores/ShortcutStore.ts
+++ b/src/frontend/lib/stores/ShortcutStore.ts
@@ -84,6 +84,33 @@ const defaultShortcuts: Omit<KeyboardShortcut, "type">[] = [
   },
 ];
 
+const shortcutIconFilterMap: ReadonlyMap<string | RegExp, string> = new Map<
+  string | RegExp,
+  string
+>([
+  ["Comma", ","],
+  ["Equal", "="],
+  ["Minus", "-"],
+  ["Period", "."],
+  ["Backslash", "\\"],
+  ["Backspace", "⌫"],
+  ["meta", "⌘"],
+  ["alt", "⌥"],
+  ["ctrl", "⌃"],
+  ["shift", "⇧"],
+  ["ArrowDown", "↓"],
+  ["ArrowUp", "↑"],
+  ["ArrowLeft", "←"],
+  ["ArrowRight", "→"],
+  ["BracketRight", "]"],
+  ["BracketLeft", "["],
+  ["Digit", ""],
+  ["Key", ""],
+  ["[", ""],
+  ["]", ""],
+  [/\+/g, " "],
+]);
+
 export type ShortcutAction = `${string}.${string}`; // Actions must be nested at least one layer deep
 export type ShortcutString = string;
 
@@ -275,6 +302,28 @@ class ShortcutStore {
     });
   }
 
+  public getFormattedShortcutsForActionReactive(
+    action: ShortcutAction
+  ): Readable<ShortcutString[]> {
+    return derived(this.shortcuts, ($shortcuts) => {
+      const shortcut = $shortcuts.get(action);
+
+      if (!shortcut) {
+        return [];
+      }
+
+      const hotkeys = shortcut.value.map((combo) => {
+        for (const [key, value] of shortcutIconFilterMap.entries()) {
+          combo = combo.replace(key, value);
+        }
+
+        return combo;
+      });
+
+      return hotkeys;
+    });
+  }
+
   public getShortcutsReactive(): Readable<KeyboardShortcut[]> {
     return derived(this.shortcuts, ($shortcuts) => {
       return Array.from($shortcuts.values());
@@ -287,31 +336,7 @@ class ShortcutStore {
 
       shortcuts.forEach((shortcut) => {
         shortcut.value = shortcut.value.map((combo) => {
-          const map = new Map<string | RegExp, string>([
-            ["Comma", ","],
-            ["Equal", "="],
-            ["Minus", "-"],
-            ["Period", "."],
-            ["Backslash", "\\"],
-            ["Backspace", "⌫"],
-            ["meta", "⌘"],
-            ["alt", "⌥"],
-            ["ctrl", "⌃"],
-            ["shift", "⇧"],
-            ["ArrowDown", "↓"],
-            ["ArrowUp", "↑"],
-            ["ArrowLeft", "←"],
-            ["ArrowRight", "→"],
-            ["BracketRight", "]"],
-            ["BracketLeft", "["],
-            ["Digit", ""],
-            ["Key", ""],
-            ["[", ""],
-            ["]", ""],
-            [/\+/g, " "],
-          ]);
-
-          for (const [key, value] of map.entries()) {
+          for (const [key, value] of shortcutIconFilterMap.entries()) {
             combo = combo.replace(key, value);
           }
 

--- a/src/frontend/ui/base/Splash.svelte
+++ b/src/frontend/ui/base/Splash.svelte
@@ -34,7 +34,7 @@
     </div>
     <div class="content">
       <img src="images/blix.svg" alt="Banner" class="inline-block w-20" />
-      <span class="float-right pt-6 opacity-90">AI Photo Editor</span><br />
+      <span class="float-right pt-6 opacity-90">The Anything Editor</span><br />
       <hr class="my-3 border-gray-400" />
       <br /><br />
       <h2>Recent projects</h2>
@@ -66,10 +66,10 @@
           {/each}
         {/await}
       </ul>
-      <br /><br /><br /><br />
+      <!-- <br /><br /><br /><br />
       <h2>Templates</h2>
       <hr class="my-3 border-gray-600" />
-      <i>No templates available</i>
+      <i>No templates available</i> -->
     </div>
   </div>
 </div>

--- a/src/frontend/ui/base/layout/Layout.svelte
+++ b/src/frontend/ui/base/layout/Layout.svelte
@@ -3,6 +3,14 @@
   import { projectsStore } from "@frontend/lib/stores/ProjectStore";
   import { faFolder } from "@fortawesome/free-solid-svg-icons";
   import Fa from "svelte-fa";
+  import { shortcutsRegistry } from "@frontend/lib/stores/ShortcutStore";
+
+  const openProjectHotkeys = shortcutsRegistry.getFormattedShortcutsForActionReactive(
+    "blix.projects.openProject"
+  );
+  const newProjectHotkeys = shortcutsRegistry.getFormattedShortcutsForActionReactive(
+    "blix.projects.newProject"
+  );
 </script>
 
 <div class="fullScreen">
@@ -13,8 +21,26 @@
   {:else}
     <div class="placeholder select-none">
       <div class="icon"><Fa icon="{faFolder}" style="display: inline-block" /></div>
-      <h1>No projects!</h1>
-      <h2>Create a project to begin creating</h2>
+      <div class="flex space-x-2 pb-2">
+        <h2 class="text-zinc-400">Open a project</h2>
+        {#each $openProjectHotkeys as hotkey}
+          <span
+            class="flex flex-nowrap items-center rounded-md bg-zinc-700 px-2 text-sm text-zinc-300 shadow-inner"
+          >
+            {hotkey}
+          </span>
+        {/each}
+      </div>
+      <div class="flex space-x-2">
+        <h2 class="text-zinc-400">Create a new project</h2>
+        {#each $newProjectHotkeys as hotkey}
+          <span
+            class="flex flex-nowrap items-center rounded-md bg-zinc-700 px-2 text-sm text-zinc-300 shadow-inner"
+          >
+            {hotkey}
+          </span>
+        {/each}
+      </div>
     </div>
   {/if}
 </div>
@@ -50,7 +76,7 @@
     }
 
     h2 {
-      font-size: 0.8em;
+      font-size: 1em;
       color: #9090a4;
     }
   }

--- a/src/frontend/ui/base/layout/Panel.svelte
+++ b/src/frontend/ui/base/layout/Panel.svelte
@@ -27,12 +27,12 @@
   import { focusedPanelStore } from "../../../lib/PanelNode";
   import { tileStore } from "../../../lib/stores/TileStore";
   import { get } from "svelte/store";
-  // import PanelBlipVane from "./PanelBlipVane.svelte";
+  import PanelBlipVane from "./PanelBlipVane.svelte";
   // import { scale } from "svelte/transition";
 
   const dispatch = createEventDispatcher();
 
-  const minSize = 10;
+  const minSize = 0;
   const tiles = get(tileStore);
 
   export let horizontal: boolean = false;
@@ -188,10 +188,12 @@
     resetBlipVane();
 
     const selection = slideOptions(e, index, dock);
+    const dir: string = e.detail.dir;
 
     switch (selection.action) {
       case "addPanel":
-        layout.addPanel(selection.data.content, selection.data.index);
+        const index = dir === "r" || dir === "d" ? selection.data.index + 1 : selection.data.index;
+        layout.addPanel(selection.data.content, index);
         layout = layout; // Force update
         break;
       case "removePanel":
@@ -203,7 +205,7 @@
         bubbleToRoot();
         break;
       case "tunnelAndSplit":
-        let group = new PanelGroup(undefined, layout.getPanel(selection.data.index).id);
+        let group = new PanelGroup();
 
         //Add this panel
         group.addPanel(selection.data.content, 0);
@@ -324,11 +326,11 @@
 
         <!-- TODO: Fix - for some reason this occasionally causes issues with panel deletion -->
         <!-- A temp workaround that seems to hold up better is awaiting tick() in PanelGroup removePanel() -->
-        <!-- {#if blipVaneIcon && i === blipVaneIndex}
+        {#if blipVaneIcon && i === blipVaneIndex}
           {#key blipVaneIcon}
-            <PanelBlipVane icon={blipVaneIcon} />
+            <PanelBlipVane icon="{blipVaneIcon}" />
           {/key}
-        {/if} -->
+        {/if}
 
         <svelte:self
           on:bubbleToRoot="{bubbleToRoot}"
@@ -346,19 +348,9 @@
   <!-- When a panel is clicked, a store is updated to hold the focussed panel -->
   <div
     class="fullPanel"
-    on:click="{() => {
-      focusedPanelStore.focusOnPanel(layout.id);
-    }}"
+    on:click="{() => focusedPanelStore.focusOnPanel(layout.id)}"
     on:keydown="{null}"
   >
-    <!-- {#if layout.content === "graph"}
-      <Graph />
-    {:else if layout.content === "image"}
-      <div class="flex h-full w-full items-center justify-center p-5">
-        <Image />
-      </div>
-    {/if} -->
-    <!-- {layout.content} -->
     <svelte:component
       this="{getComponentForPanelType(layout.content)}"
       signature="{layout.content}"
@@ -385,6 +377,14 @@
     background-color: #11111b;
     border: none;
     transition: all 0.3s ease-in-out;
+  }
+
+  .splitpanes--horizontal > .splitpanes__splitter {
+    height: 5px !important;
+  }
+
+  .splitpanes--vertical > .splitpanes__splitter {
+    width: 5px !important;
   }
 
   .splitpanes.main-theme .splitpanes__splitter:active {

--- a/src/frontend/ui/base/layout/PanelBlipVane.svelte
+++ b/src/frontend/ui/base/layout/PanelBlipVane.svelte
@@ -32,8 +32,6 @@
 
   let panelWidth: number;
   let panelHeight: number;
-
-  $: console.log(panelWidth, panelHeight);
 </script>
 
 {#if icon !== null}


### PR DESCRIPTION
I refactored some of the `PanelNode` code to use uniquely generated string id's instead of just integer counter id's. This seems to have fix the deletion exception bug. Might have been something to do with the #keyed blocks in Svelte not but not sure. Also found some one or two small bugs here and there that I fixed as well.